### PR TITLE
fix: remove succeeded pods when meta full sync

### DIFF
--- a/pkg/k8s/k8ssync/metasync.go
+++ b/pkg/k8s/k8ssync/metasync.go
@@ -131,6 +131,9 @@ func (rs *resourceSyncer) start(stopCh <-chan struct{}) {
 			}
 
 			for _, item := range items {
+				if rs.funcs.delete != nil && rs.funcs.delete(item) {
+					continue
+				}
 				req.Resources = append(req.Resources, rs.funcs.convert(item))
 			}
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Succeeded pods now will be sync to server side through `Meta Full Sync`, which can lead to duplicated pod IP in server side.
The current server side's handling of pod IP is not very robust. Duplicated pod IP can lead to many problems.

So let's try to remove succeeded pods, which is a temporary fix.

# What changes are included in this PR?
Remove succeeded pod when meta full sync

# Are there any user-facing changes?
No

# How does this change test
Local test
