### PR TITLE
chore: Add workspace as a tag of metrics

### DIFF
--- a/pkg/collectconfig/executor/consumer.go
+++ b/pkg/collectconfig/executor/consumer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/traas-stack/holoinsight-agent/pkg/collectconfig/executor/logstream"
 	"github.com/traas-stack/holoinsight-agent/pkg/collectconfig/executor/storage"
 	"github.com/traas-stack/holoinsight-agent/pkg/collecttask"
+	"github.com/traas-stack/holoinsight-agent/pkg/core"
 	"github.com/traas-stack/holoinsight-agent/pkg/ioc"
 	"github.com/traas-stack/holoinsight-agent/pkg/logger"
 	"github.com/traas-stack/holoinsight-agent/pkg/model"
@@ -487,6 +488,9 @@ func (c *Consumer) addCommonTags(d *model.DetailData) {
 		if _, ok := d.Tags["app"]; !ok && appconfig.StdAgentConfig.App != "" {
 			d.Tags["app"] = appconfig.StdAgentConfig.App
 		}
+	}
+	if appconfig.StdAgentConfig.Mode == core.AgentModeDaemonset {
+		d.Tags["workspace"] = appconfig.StdAgentConfig.Workspace
 	}
 }
 

--- a/pkg/k8s/k8ssync/metasync.go
+++ b/pkg/k8s/k8ssync/metasync.go
@@ -131,6 +131,9 @@ func (rs *resourceSyncer) start(stopCh <-chan struct{}) {
 			}
 
 			for _, item := range items {
+				if rs.funcs.delete != nil && rs.funcs.delete(item) {
+					continue
+				}
 				req.Resources = append(req.Resources, rs.funcs.convert(item))
 			}
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
`workspace` is a reserved tag for HoloInsight and is used to separate data from different environments.

# What changes are included in this PR?
Add workspace as a tag of metrics.

# Are there any user-facing changes?

# How does this change test
