### PR TITLE
fix: disable CGO for containerhelper

### DIFF
--- a/scripts/build/build-using-go.sh
+++ b/scripts/build/build-using-go.sh
@@ -27,10 +27,10 @@ echo gitcommit=$gitcommit
 
 # https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
 (cd $project_root && \
-  go build \
+  CGO_ENABLED=1 go build \
   -ldflags "-s -w" \
   -ldflags "-X github.com/traas-stack/holoinsight-agent/pkg/appconfig.agentVersion=$version \
   -X github.com/traas-stack/holoinsight-agent/pkg/appconfig.agentBuildTime=$buildTime \
   -X github.com/traas-stack/holoinsight-agent/pkg/appconfig.gitcommit=$gitcommit" \
   -o build/$GOOS-$GOARCH/bin/agent ./cmd/agent && \
-  go build -ldflags "-s -w" -o build/$GOOS-$GOARCH/bin/helper ./cmd/containerhelper)
+  CGO_ENABLED=0 go build -ldflags "-s -w" -o build/$GOOS-$GOARCH/bin/helper ./cmd/containerhelper)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #13 

# Rationale for this change
Disable CGO for containerhelper. So it can run in Alpine based container.

# What changes are included in this PR?
Disable CGO for containerhelper. So it can run in Alpine based container.


# Are there any user-facing changes?
No

# How does this change test
Local test
