### PR TITLE
fix: fix k8s panic

### DIFF
--- a/pkg/k8s/k8smeta/node.go
+++ b/pkg/k8s/k8smeta/node.go
@@ -1,7 +1,6 @@
 package k8smeta
 
 import (
-	"errors"
 	"github.com/traas-stack/holoinsight-agent/pkg/k8s/k8sutils"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -25,9 +24,7 @@ var (
 		NodeIndexByIp: func(obj interface{}) ([]string, error) {
 			node := obj.(*v1.Node)
 			ip := k8sutils.GetNodeIP(node)
-			if ip == "" {
-				return nil, errors.New("no ip")
-			}
+			// If we return err here, it will lead to panic in k8s internal !!!
 			return []string{ip}, nil
 		},
 	}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Return nil in `IndexFunc` will lead to panic in k8s internal.

# What changes are included in this PR?
Return empty string when meet broken node to avoid panic.

# Are there any user-facing changes?

# How does this change test

