### PR TITLE
refactor: rename log analysis metric names

### DIFF
--- a/pkg/collectconfig/executor/consumer_log_sub_analysis.go
+++ b/pkg/collectconfig/executor/consumer_log_sub_analysis.go
@@ -101,6 +101,7 @@ func (c *logAnalysisSubConsumer) ProcessGroup(iw *inputWrapper, ctx *LogContext,
 	var state *logAnalysisSubConsumerState
 	if shard.Data == nil {
 		state = newLogAnalysisSubConsumerState(c.conf)
+		shard.Data = state
 	} else {
 		state = shard.Data.(*logAnalysisSubConsumerState)
 	}
@@ -187,7 +188,7 @@ func (c *logAnalysisSubConsumer) Emit(expectedTs int64) bool {
 			Timestamp: expectedTs,
 			Tags:      map[string]string{"eventName": "__analysis"},
 			Values: map[string]interface{}{
-				"value": util.ToJsonString(&loganalysis.Unknown{
+				"analysis": util.ToJsonString(&loganalysis.Unknown{
 					AnalyzedLogs: analyzedLogs,
 				}),
 			},
@@ -197,7 +198,7 @@ func (c *logAnalysisSubConsumer) Emit(expectedTs int64) bool {
 			Timestamp: expectedTs,
 			Tags:      map[string]string{"eventName": "__analysis"},
 			Values: map[string]interface{}{
-				"count": unknownPatternLogsCount,
+				"value": unknownPatternLogsCount,
 			},
 			SingleValue: false,
 		})


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
rename log analysis metric names:
1. count: old=${prefix}_count, new=${prefix}
2. analysis: old=${prefix}, new=${prefix}_analysis

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
