### PR TITLE
refactor: multiline filter

### DIFF
--- a/pkg/collectconfig/executor/consumer.go
+++ b/pkg/collectconfig/executor/consumer.go
@@ -787,6 +787,21 @@ func (c *Consumer) executeBeforeParseWhere(ctx *LogContext) bool {
 	if c.BeforeParseWhere == nil {
 		return true
 	}
+
+	// When execute 'beforeParseWhere', we treat whole line group as a string.
+	// So many filters don't need to consider the multiline situation.
+	if len(ctx.log.Lines) > 0 {
+		content := strings.Join(ctx.log.Lines, "\n")
+		bak := ctx.log
+		ctx.log = &LogGroup{
+			Line:  content,
+			Lines: []string{content},
+		}
+		defer func() {
+			ctx.log = bak
+		}()
+	}
+
 	if b, err := c.BeforeParseWhere.Test(ctx); !b {
 		if err != nil {
 			if ctx.event != nil {

--- a/pkg/collectconfig/executor/multiline.go
+++ b/pkg/collectconfig/executor/multiline.go
@@ -26,7 +26,7 @@ func parseMultiline(cfg *collectconfig.FromLogMultiline) (*xMultiline, error) {
 		return nil, nil
 	}
 	if cfg.Where == nil {
-		return nil, errors.New("multiline.start is nil")
+		return nil, errors.New("multiline.where is nil")
 	}
 	what := multilineWhatPrevious
 	switch cfg.What {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
When execute 'beforeParseWhere', we treat whole line group as a string.
So many filters don't need to consider the multiline situation.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
