### PR TITLE
fix: normalize GPU utilization

### DIFF
--- a/pkg/plugin/input/nvidia_smi/nvidia_smi.go
+++ b/pkg/plugin/input/nvidia_smi/nvidia_smi.go
@@ -92,6 +92,8 @@ func convertToFloat64(item *queryItem, str string) (float64, error) {
 	}
 	if strings.HasSuffix(str, " %") {
 		str = str[:len(str)-2]
+		v, err := cast.ToFloat64E(str)
+		return v / 100, err
 	}
 	if strings.HasSuffix(str, " W") {
 		str = str[:len(str)-2]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Currently, the range of GPU utilization values is [0,100], which needs to be normalized to [0,1].
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- normalize GPU utilization

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
NO

# How does this change test
Local test
