### PR TITLE
fix: listener deletion

### DIFF
--- a/pkg/collectconfig/executor/logstream/logstream_g.go
+++ b/pkg/collectconfig/executor/logstream/logstream_g.go
@@ -147,9 +147,15 @@ func (f *GLogStream) RemoveListener(listener Listener, cursor int64) {
 
 	listeners := make([]Listener, 0, len(f.Listeners))
 	for _, l := range f.Listeners {
+		// The implementations of Listener must not be empty structs.
+		// They will result in same object address when their instances are converted to Listener interface,
+		// which leads to the following 'l!=listener' always returns false
 		if l != listener {
 			listeners = append(listeners, l)
 		}
+	}
+	if x := len(f.Listeners) - len(listeners); x > 1 {
+		logger.Errorz("remove multi listeners", zap.String("key", f.Key), zap.Int("old", len(f.Listeners)), zap.Int("new", len(listeners)))
 	}
 	f.Listeners = listeners
 

--- a/pkg/collectconfig/executor/pipeline.go
+++ b/pkg/collectconfig/executor/pipeline.go
@@ -35,7 +35,9 @@ const (
 )
 
 type (
-	listenerImpl struct{}
+	listenerImpl struct {
+		_ int
+	}
 
 	// LogPipeline is responsible for detecting log inputs(see inputsManager) , scheduling pulling logs task, and put logs to consumer.
 	LogPipeline struct {
@@ -162,7 +164,6 @@ func (iw *inputWrapper) read() (*logstream.ReadResponse, int64, error) {
 
 func (l *listenerImpl) Changed(ls logstream.LogStream, lcursor int64) {
 }
-
 func (p *LogPipeline) Key() string {
 	return p.st.CT.Key
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Listeners were mistakenly deleted.
The implementations of Listener must not be empty structs.
They will result in same object address when their instances are converted to Listener interface,
which leads to the following 'l!=listener' always returns false

```Golang
func (f *GLogStream) RemoveListener(listener Listener, cursor int64) {
	f.Mutex.Lock()
	defer f.Mutex.Unlock()

	listeners := make([]Listener, 0, len(f.Listeners))
	for _, l := range f.Listeners {
		// The implementations of Listener must not be empty structs.
		// They will result in same object address when their instances are converted to Listener interface,
		// which leads to the following 'l!=listener' always returns false
		if l != listener {
			listeners = append(listeners, l)
		}
	}
	if x := len(f.Listeners) - len(listeners); x > 1 {
		logger.Errorz("remove multi listeners", zap.String("key", f.Key), zap.Int("old", len(f.Listeners)), zap.Int("new", len(listeners)))
	}
	f.Listeners = listeners

	for i := cursor; i < f.Cursor; i++ {
		f.getFromCache(i)
	}
}
```

# What changes are included in this PR?
- Add a field to listenerImpl


# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
