### PR TITLE
fix: close cri

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -320,6 +320,7 @@ func (b *AgentBootstrap) setupDaemonAgent() error {
 	if err := b.setupCRI(); err != nil {
 		return err
 	}
+	b.AddStopComponents(ioc.Crii)
 
 	// system metrics
 	{
@@ -355,7 +356,7 @@ func (b *AgentBootstrap) setupDaemonAgent() error {
 	bsm := bistream.NewManager(ioc.RegistryService, bizbistream.GetBiStreamHandlerRegistry())
 
 	b.TM = manager.NewTransferManager(b.PM, b.LSM)
-	b.TM.AddStopComponents(b.httpServerComponent, ctm, bsm, b.AM)
+	b.TM.AddStopComponents(b.httpServerComponent, ctm, bsm, b.AM, ioc.Crii)
 	if err := b.TM.Transfer(); err != nil {
 		logger.Errorz("[transfer] error", zap.Error(err))
 	}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
The `defaultCri` will start http and socks5 proxy in `Start()` func.
When upgrade holoinsight-agent using lossless mode, the relevant ports are not closed, causing the http and socks5 proxy servers to fail to start.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Close `cri.Interface` when transfering
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
