### PR TITLE
fix: fix docker exec stdout EOF missing

### DIFF
--- a/cmd/containerhelper/handlers/all.go
+++ b/cmd/containerhelper/handlers/all.go
@@ -18,4 +18,5 @@ func init() {
 	model.RegisterHandler("inputProxy", inputProxyHandler)
 	model.RegisterHandler("httpProxy", httpProxyHandler)
 	model.RegisterHandler("tcpProxy", tcpProxyHandler)
+	model.RegisterHandler("fixout", fixOutHandler)
 }

--- a/cmd/containerhelper/handlers/fixout.go
+++ b/cmd/containerhelper/handlers/fixout.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+package handlers
+
+import (
+	fixout2 "github.com/traas-stack/holoinsight-agent/cmd/containerhelper/handlers/fixout"
+	"github.com/traas-stack/holoinsight-agent/cmd/containerhelper/model"
+	"os"
+	"os/exec"
+)
+
+// fixOutHandler will run another process and encode the stdout/stderr of that process into fixOutHandler's stdout.
+func fixOutHandler(action string, resp *model.Resp) error {
+	// build cmd
+	cmd := exec.Command(os.Args[2], os.Args[3:]...)
+	cmd.Stdin = os.Stdin
+	stdoutr, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderrr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	errChan := make(chan error, 2)
+	// encode cmd's stdout and stderr into os.Stdout
+	go fixout2.CopyStream(fixout2.StdoutFd, stdoutr, errChan)
+	go fixout2.CopyStream(fixout2.StderrFd, stderrr, errChan)
+
+	wait := 2
+loop:
+	for {
+		select {
+		case <-errChan:
+			wait--
+			if wait == 0 {
+				cmd.Wait()
+				// done
+				break loop
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/containerhelper/handlers/fixout/common.go
+++ b/cmd/containerhelper/handlers/fixout/common.go
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+package fixout
+
+const (
+	StdoutFd = 1
+	StderrFd = 2
+	bufSize  = 4096
+)

--- a/cmd/containerhelper/handlers/fixout/decode.go
+++ b/cmd/containerhelper/handlers/fixout/decode.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+package fixout
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+func Decode(hr *io.PipeReader, stdoutW io.WriteCloser, stderrW io.WriteCloser) error {
+	var err error
+	activeFdCount := 2
+	for activeFdCount > 0 {
+		var fd byte
+		var size int16
+		if err = binary.Read(hr, binary.LittleEndian, &fd); err != nil {
+			break
+		}
+		if err = binary.Read(hr, binary.LittleEndian, &size); err != nil {
+			break
+		}
+		if size == -1 {
+			activeFdCount--
+			switch fd {
+			case StdoutFd:
+				stdoutW.Close()
+			case StderrFd:
+				stderrW.Close()
+			}
+			continue
+		}
+		switch fd {
+		case StdoutFd:
+			_, err = io.CopyN(stdoutW, hr, int64(size))
+		case StderrFd:
+			_, err = io.CopyN(stderrW, hr, int64(size))
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/containerhelper/handlers/fixout/encode.go
+++ b/cmd/containerhelper/handlers/fixout/encode.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+package fixout
+
+import (
+	"encoding/binary"
+	"io"
+	"os"
+	"sync"
+)
+
+var (
+	writeLock sync.Mutex
+)
+
+func write(fd int, payload []byte) error {
+	writeLock.Lock()
+	defer writeLock.Unlock()
+
+	// fd 1 byte
+	// size 2 bytes
+	// payload <size> bytes (optional)
+	if err := binary.Write(os.Stdout, binary.LittleEndian, byte(fd)); err != nil {
+		return err
+	}
+	if err := binary.Write(os.Stdout, binary.LittleEndian, int16(len(payload))); err != nil {
+		return err
+	}
+	return binary.Write(os.Stdout, binary.LittleEndian, payload)
+}
+
+func writeClose(fd int) error {
+	writeLock.Lock()
+	defer writeLock.Unlock()
+
+	// fd 1 byte
+	// -1 2 bytes (const)
+	if err := binary.Write(os.Stdout, binary.LittleEndian, byte(fd)); err != nil {
+		return err
+	}
+	return binary.Write(os.Stdout, binary.LittleEndian, int16(-1))
+}
+
+// copyStream reads bytes from in, and encodes bytes into os.Stdout
+func CopyStream(fd int, in io.Reader, errChan chan error) {
+	buf := make([]byte, bufSize)
+	for {
+		n, err := in.Read(buf)
+		var err2 error
+		if n > 0 {
+			err2 = write(fd, buf[:n])
+		}
+		if err == io.EOF {
+			if err2 == nil {
+				err2 = writeClose(fd)
+			}
+		}
+		if err == nil {
+			err = err2
+		}
+		if err != nil {
+			errChan <- err
+			if err != io.EOF {
+				io.Copy(io.Discard, in)
+			}
+			break
+		}
+	}
+}

--- a/pkg/cri/api.go
+++ b/pkg/cri/api.go
@@ -135,7 +135,8 @@ type (
 		WorkingDir string   `json:"workingDir"`
 		Input      io.Reader
 		// User is the user passed to docker exec, defaults to 'root'
-		User string
+		User   string
+		FixOut bool
 	}
 )
 

--- a/pkg/cri/impl/default_cri.go
+++ b/pkg/cri/impl/default_cri.go
@@ -956,5 +956,11 @@ func (e *defaultCri) ExecAsync(ctx context.Context, c *cri.Container, req cri.Ex
 	if req.User == "" {
 		req.User = defaultExecUser
 	}
+	logger.Criz("[digest] exec async",
+		zap.String("engine", e.engine.Type()),
+		zap.String("cid", c.ShortContainerID()),
+		zap.String("runtime", c.Runtime),
+		zap.Strings("cmd", req.Cmd),
+		zap.Strings("env", req.Env))
 	return e.engine.ExecAsync(ctx, c, req)
 }

--- a/pkg/cri/impl/netproxy/common.go
+++ b/pkg/cri/impl/netproxy/common.go
@@ -7,6 +7,7 @@ package netproxy
 import (
 	"context"
 	"github.com/traas-stack/holoinsight-agent/pkg/cri"
+	"net"
 	"net/http"
 	"time"
 )
@@ -17,13 +18,19 @@ const (
 )
 
 type (
-	Handler func(ctx context.Context, pod *cri.Pod, req *http.Request) (*http.Request, *http.Response, error)
+	HttpHandler func(ctx context.Context, pod *cri.Pod, req *http.Request) (*http.Request, *http.Response, error)
+	TcpHandler  func(ctx context.Context, i cri.Interface, c *cri.Container, addr string, dialTimeout time.Duration) (net.Conn, error)
 )
 
 var (
-	handlers []Handler
+	handlers    []HttpHandler
+	tcpHandlers []TcpHandler
 )
 
-func AddHttpProxyHandler(handler Handler) {
+func AddHttpProxyHandler(handler HttpHandler) {
 	handlers = append(handlers, handler)
+}
+
+func AddTcpProxyHandler(handler TcpHandler) {
+	tcpHandlers = append(tcpHandlers, handler)
 }

--- a/pkg/cri/impl/netproxy/port_forward.go
+++ b/pkg/cri/impl/netproxy/port_forward.go
@@ -80,7 +80,7 @@ func (t *PortForwardTask) Start(ctx context.Context) (string, error) {
 func handlePortForwardRequest(logCtx zap.Option, biz *cri.Container, conn net.Conn, addr string) {
 	defer conn.Close()
 
-	subConn, err := criutils.TcpProxy(logger.WithLogCtx(context.Background(), logCtx), ioc.Crii, biz, addr, DefaultDialTimeout)
+	subConn, err := tcpProxy(logger.WithLogCtx(context.Background(), logCtx), ioc.Crii, biz, addr, DefaultDialTimeout)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -201,3 +201,11 @@ func (h *DnsCacheHelper) NewHttpClient() *http.Client {
 func dial(ctx context.Context, network, addr string) (net.Conn, error) {
 	return NewDnsCacheHelper().Dial(ctx, network, addr)
 }
+
+func ReplaceHost(hostport string, host string) string {
+	_, port, err := net.SplitHostPort(hostport)
+	if err == nil {
+		return net.JoinHostPort(host, port)
+	}
+	return host
+}

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestReplaceHost(t *testing.T) {
+	assert.Equal(t, "2.2.2.2:2222", ReplaceHost("1.1.1.1:2222", "2.2.2.2"))
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
When using the docker exec function, we have no way to perceive the stdout EOF or stderr EOF event of exec. We can only wait until the entire `resp.Reader` EOF before we can consider that both stdout and stderr are EOF. This will cause the connection to hang in some scenarios that rely heavily on the EOF signal.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Add an auxiliary command fixOut, which can execute a child process and re-encode the stdout and stderr of the child process, including the EOF signal.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
