### PR TITLE
fix: wrap exec with timeout and _FROM env

### DIFF
--- a/pkg/cri/impl/engine/containerd_engine.go
+++ b/pkg/cri/impl/engine/containerd_engine.go
@@ -283,13 +283,13 @@ func (e *ContainerdContainerEngine) Exec(ctx context.Context, c *cri.Container, 
 
 	pspec := spec.Process
 	pspec.Terminal = false
-	pspec.Args = req.Cmd
+	pspec.Args = wrapTimeout(req.Cmd)
 	if req.WorkingDir != "" {
 		pspec.Cwd = req.WorkingDir
 	}
 
 	// Append user specified env
-	pspec.Env = append(pspec.Env, req.Env...)
+	pspec.Env = wrapEnv(append(pspec.Env, req.Env...))
 
 	task, err := container.Task(ctx, nil)
 	if err != nil {
@@ -424,13 +424,13 @@ func (e *ContainerdContainerEngine) ExecAsync(ctx context.Context, c *cri.Contai
 
 	pspec := spec.Process
 	pspec.Terminal = false
-	pspec.Args = req.Cmd
+	pspec.Args = wrapTimeout(req.Cmd)
 	if req.WorkingDir != "" {
 		pspec.Cwd = req.WorkingDir
 	}
 
 	// Append user specified env
-	pspec.Env = append(pspec.Env, req.Env...)
+	pspec.Env = wrapEnv(append(pspec.Env, req.Env...))
 
 	task, err := container.Task(ctx, nil)
 	if err != nil {

--- a/pkg/cri/impl/engine/docker_engine.go
+++ b/pkg/cri/impl/engine/docker_engine.go
@@ -131,9 +131,9 @@ func (e *DockerContainerEngine) Exec(ctx context.Context, c *cri.Container, req 
 		AttachStdout: true,
 		Detach:       false,
 		DetachKeys:   "",
-		Env:          req.Env,
+		Env:          wrapEnv(req.Env),
 		WorkingDir:   req.WorkingDir,
-		Cmd:          req.Cmd,
+		Cmd:          wrapTimeout(req.Cmd),
 	})
 	if err != nil {
 		return invalidResult, err
@@ -239,9 +239,9 @@ func (e *DockerContainerEngine) ExecAsync(ctx context.Context, c *cri.Container,
 		AttachStdout: true,
 		Detach:       false,
 		DetachKeys:   "",
-		Env:          req.Env,
+		Env:          wrapEnv(req.Env),
 		WorkingDir:   req.WorkingDir,
-		Cmd:          hackedCmd,
+		Cmd:          wrapTimeout(hackedCmd),
 	})
 	if err != nil {
 		return invalidResult, err

--- a/pkg/cri/impl/engine/utils.go
+++ b/pkg/cri/impl/engine/utils.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Holoinsight Project Authors. Licensed under Apache-2.0.
+ */
+
+package engine
+
+import (
+	"github.com/spf13/cast"
+	"os"
+)
+
+var (
+	timeout = "180"
+)
+
+func init() {
+	s := os.Getenv("CRI_EXEC_TIMEOUT")
+	if x := cast.ToInt(s); x > 0 {
+		timeout = s
+	}
+}
+
+// wrapTimeout wraps cmd with timeout -s KILL <seconds> to prevent the process from hanging and not exiting for any reason.
+func wrapTimeout(cmd []string) []string {
+	// timeout -s KILL <seconds> cmd...
+	return append([]string{"timeout", "-s", "KILL", timeout}, cmd...)
+}
+
+// wrapEnv wraps envs with _FROM=holoinsight-agent. This env is used to mark the source of the call.
+func wrapEnv(envs []string) []string {
+	return append(envs, "_FROM=holoinsight-agent")
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
The target process may hang and not exit for any reason.  
We encountered this in practice. I guessed some reasons, but it was difficult to reproduce stably.

# What changes are included in this PR?
- `wrapTimeout` wraps cmd with `timeout -s KILL <seconds>` to prevent the process from hanging and not exiting for any reason.
- `wrapEnv` wraps envs with `_FROM=holoinsight-agent`. This env is used to mark the source of the call.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
