### PR TITLE
fix: fix docker exec zombies

### DIFF
--- a/cmd/containerhelper/handlers/countZombies.go
+++ b/cmd/containerhelper/handlers/countZombies.go
@@ -30,18 +30,12 @@ func countZombiesHandler(_ string, resp *model.Resp) error {
 		if _, err := strconv.ParseInt(info.Name(), 10, 32); err != nil {
 			return nil
 		}
-		content, err := os.ReadFile(filepath.Join(path, "/status"))
+		content, err := os.ReadFile(filepath.Join(path, "/stat"))
 		if err != nil {
 			return nil
 		}
-		lines := strings.Split(string(content), "\n")
-		for _, line := range lines {
-			if strings.HasPrefix(line, "State:") {
-				if strings.Contains(line, "zombie") {
-					count++
-				}
-				break
-			}
+		if strings.Contains(string(content), ") Z 1 ") {
+			count++
 		}
 		if count > countLimit {
 			return filepath.SkipAll

--- a/pkg/cri/api.go
+++ b/pkg/cri/api.go
@@ -121,6 +121,7 @@ type (
 		Hostname    string
 		Runtime     string
 		NetworkMode string
+		PidMode     string
 		MergedDir   string
 		LogPath     string
 		Mounts      []*MountPoint

--- a/pkg/cri/criutils/copy.go
+++ b/pkg/cri/criutils/copy.go
@@ -398,7 +398,7 @@ func CopyToContainerByChunk(ctx context.Context, i cri.Interface, c *cri.Contain
 			})
 
 			if err != nil {
-				logger.Criz("[digest] copy chunk error", zap.String("cid", c.ShortContainerID()), zap.Int("accSize", accSize), zap.Error(err))
+				logger.Criz("[digest] copy chunk error", zap.String("cid", c.ShortID()), zap.Int("accSize", accSize), zap.Error(err))
 				return err
 			}
 

--- a/pkg/cri/impl/default_cri_http.go
+++ b/pkg/cri/impl/default_cri_http.go
@@ -52,7 +52,7 @@ func (e *defaultCri) registerHttpHandlers() {
 					continue
 				}
 				if container.Hacked == 1 || container.Hacked == 5 {
-					ret = append(ret, container.ShortContainerID())
+					ret = append(ret, container.ShortID())
 				}
 			}
 		}

--- a/pkg/cri/impl/engine/containerd_engine.go
+++ b/pkg/cri/impl/engine/containerd_engine.go
@@ -216,6 +216,7 @@ func (e *ContainerdContainerEngine) GetContainerDetail(ctx context.Context, cid 
 
 	if detail.IsSandbox {
 		detail.NetworkMode = "netns:" + sandboxMeta.NetNSPath
+		// TODO detail.PidMode
 	}
 
 	// I don't know how to get containerd's state dir.

--- a/pkg/cri/impl/engine/docker_engine.go
+++ b/pkg/cri/impl/engine/docker_engine.go
@@ -82,6 +82,7 @@ func (e *DockerContainerEngine) GetContainerDetail(ctx context.Context, cid stri
 		Hostname:    i.Config.Hostname,
 		Runtime:     i.HostConfig.Runtime,
 		NetworkMode: string(i.HostConfig.NetworkMode),
+		PidMode:     string(i.HostConfig.PidMode),
 		MergedDir:   "",
 		Mounts:      nil,
 		State: cri.ContainerState{

--- a/pkg/cri/impl/metastore.go
+++ b/pkg/cri/impl/metastore.go
@@ -171,7 +171,7 @@ func newInternalState() *internalState {
 
 func (s *internalState) build() {
 	for _, c := range s.containerMap {
-		s.shortCidContainerMap[c.criContainer.ShortContainerID()] = c
+		s.shortCidContainerMap[c.criContainer.ShortID()] = c
 	}
 	for _, pod := range s.pods {
 		if pod.IsRunning() {

--- a/pkg/cri/impl/netproxy/port_forward.go
+++ b/pkg/cri/impl/netproxy/port_forward.go
@@ -57,7 +57,7 @@ func (t *PortForwardTask) Start(ctx context.Context) (string, error) {
 			stopCh <- struct{}{}
 		}
 	}()
-	logCtx := zap.Fields(zap.String("uuid", uuid.New().String()), zap.String("cid", biz.ShortContainerID()), zap.String("listenAddr", listener.Addr().String()), zap.String("toAddr", t.Addr))
+	logCtx := zap.Fields(zap.String("uuid", uuid.New().String()), zap.String("cid", biz.ShortID()), zap.String("listenAddr", listener.Addr().String()), zap.String("toAddr", t.Addr))
 	logger.Infozo(logCtx, "[netproxy] create port forward")
 
 	go func() {

--- a/pkg/cri/impl/netproxy/proxy_socks5.go
+++ b/pkg/cri/impl/netproxy/proxy_socks5.go
@@ -95,7 +95,7 @@ func (h *CriHandle) tcpHandle(s *socks5.Server, c *net.TCPConn, r *socks5.Reques
 
 	uuid2 := uuid.New().String()
 
-	logCtx := zap.Fields(zap.String("uuid", uuid2), zap.String("protocol", "socks5"), zap.String("cid", biz.ShortContainerID()), zap.String("addr", addr))
+	logCtx := zap.Fields(zap.String("uuid", uuid2), zap.String("protocol", "socks5"), zap.String("cid", biz.ShortID()), zap.String("addr", addr))
 
 	proxied, err := TcpProxy(logger.WithLogCtx(context.Background(), logCtx), h.Cri, biz, addr, DefaultDialTimeout)
 	if err != nil {

--- a/pkg/cri/model.go
+++ b/pkg/cri/model.go
@@ -109,21 +109,23 @@ type (
 		// NetworkMode
 		NetworkMode string
 
+		// If PidMode is "host", it means that the container uses the pid namespace of the physical machine.
+		PidMode string
+
 		// docker json log: https://docs.docker.com/config/containers/logging/json-file/
 		LogPath string
 
 		// Attributes can be used to prevent arbitrary extension fields
 		Attributes sync.Map
 
-		// name of pid 1
-		// tini systemd java python
+		// The number of zombie processes inside the container
+		ZombieCount int
+
+		// pid 1 process name
 		Pid1Name string
 
-		// Is this container based on alpine?
-		IsAlpine AlpineStatus
-
-		// The number of zombie processes inside the container
-		ZombiesCount int
+		// Whether pid 1 has the ability to recycle zombie processes
+		Pid1CanRecycleZombieProcesses bool
 	}
 	ContainerState struct {
 		Pid    int
@@ -211,7 +213,7 @@ func (c *Container) IsRunning() bool {
 	return c.State.Pid > 0 && c.State.Status == "running"
 }
 
-func (c *Container) ShortContainerID() string {
+func (c *Container) ShortID() string {
 	return ShortContainerId(c.Id)
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
We previously used timeout to wrap the command to be executed to prevent the command from hanging and not exiting due to various reasons.
However, it was found that in Alpine-based containers, if process 1 does not have the ability to recycle zombie processes, timeout will cause zombie processes to be generated.
Eventually causing the container to OOM.

Therefore, we need to add detection logic and use timeout to wrap the command to be executed only when ensuring that the target container has the ability to recycle zombie processes.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
